### PR TITLE
Improve measure performance and measure `trigger` as well

### DIFF
--- a/addon/initializers/ember-perf-timeline.js
+++ b/addon/initializers/ember-perf-timeline.js
@@ -13,34 +13,53 @@ export function renderGetComponentDefinitionTimeString(payload) {
   return `${payload.object} (Rendering: getComponentDefinition)`;
 }
 
+let HAS_PERFORMANCE_API = false;
+
+function detectPerformanceApi() {
+  return typeof performance !== 'undefined' &&
+    typeof performance.mark === 'function' &&
+    typeof performance.measure === 'function';
+}
+
 function startMark(label) {
-  performance.mark(`${label}-start`);
+  if (HAS_PERFORMANCE_API) {
+    performance.mark(`${label}-start`);
+  } else {
+    console.time(label);
+  }
 }
 
 function endMark(label) {
-  let startMark = `${label}-start`;
-  let endMark = `${label}-end`;
-  performance.mark(endMark);
-  performance.measure(label, startMark, endMark);
+  if (HAS_PERFORMANCE_API) {
+    let startMark = `${label}-start`;
+    let endMark = `${label}-end`;
+    performance.mark(endMark);
+    performance.measure(label, startMark, endMark);
+  } else {
+    console.timeEnd(label);
+  }
 }
 
 let hasLocation = typeof self !== 'undefined' && typeof self.location === 'object';
 let shouldActivatePerformanceTracing = hasLocation && /[\?\&]_ember-perf-timeline=true/ig.test(self.location.search);
 
 if (shouldActivatePerformanceTracing) {
+  HAS_PERFORMANCE_API = detectPerformanceApi();
+
   let EVENT_ID = 0;
-  // performance.clearMeasures = function() {};
+
+  // prevent folks from force-flushing this queue when we are active
+  if (HAS_PERFORMANCE_API) {
+    performance.clearMeasures = function() {};
+  }
 
   const TriggerMixin = Ember.Mixin.create({
     trigger(eventName) {
       let eventId = EVENT_ID++;
-      let label = `${this._debugContainerKey}:${eventName}`;
-      let startMark = `${eventId}-start`;
-      let endMark = `${eventId}-end`;
-      performance.mark(startMark);
+      let label = `${this.toString()}:${eventName}:${eventId}`;
+      startMark(label);
       let ret = this._super.apply(this, arguments);
-      performance.mark(endMark);
-      performance.measure(label, startMark, endMark);
+      endMark(label);
       return ret;
     }
   });


### PR DESCRIPTION
This moves us to using `performance.mark` and `performance.measure` instead of `console.time` and `console.timeEnd` which reduces the overhead of instrumentation. Further: it instruments `Evented`'s `trigger` method in a way that catches

- events on Services that implement Evented (by reopening the Evented mixin)
- events on Models (by reopening with the Trigger override)
- events on Components (by reopening with the Trigger override)

It avoids looking up and reopening `DS.Model` if ember-data is not present.

We may want to add it to `Route` as well, but I was unsure if Route implemented Evented by default and didn't want to introduce it if not.