### PR TITLE
only register instrumentations if any instrumentations are enabled at all

### DIFF
--- a/addon/initializers/ember-perf-timeline.js
+++ b/addon/initializers/ember-perf-timeline.js
@@ -83,9 +83,9 @@ function endMark(label) {
 
 const hasLocation =
   typeof self !== 'undefined' && typeof self.location === 'object';
+const instrumentations = hasLocation && instrumentationsFromSearch(self.location.search);
 
-if (hasLocation) {
-  const instrumentations = instrumentationsFromSearch(self.location.search);
+if (instrumentations) {
   const ENABLE_ALL = instrumentations === 'true';
 
   const RENDER_COMPONENT =


### PR DESCRIPTION
fixes #34 

This restore the previous behaviour (before https://github.com/ember-best-practices/ember-perf-timeline/commit/ae8e47dc703cccaa2b137fa04f4bb3322535d6b9) where mixins etc are injected only if we switch on instrumentation